### PR TITLE
Renamed integration test classes for maven compatibility

### DIFF
--- a/src/test/java/wf/bitcoin/javabitcoindrpcclient/integration/RawTransactionsTest.java
+++ b/src/test/java/wf/bitcoin/javabitcoindrpcclient/integration/RawTransactionsTest.java
@@ -21,7 +21,7 @@ import wf.bitcoin.javabitcoindrpcclient.BitcoindRpcClient.Unspent;
  * 
  * @see <a href="https://bitcoincore.org/en/doc/0.18.0/rpc/">Bitcoin Core RPC documentation</a>
  */
-public class RawTransactionsTests extends IntegrationTestBase
+public class RawTransactionsTest extends IntegrationTestBase
 {
 	@Test(expected = Test.None.class) // no exception expected
 	public void signRawTransactionWithKeyTest_P2SH_MultiSig()

--- a/src/test/java/wf/bitcoin/javabitcoindrpcclient/integration/WalletTest.java
+++ b/src/test/java/wf/bitcoin/javabitcoindrpcclient/integration/WalletTest.java
@@ -14,7 +14,7 @@ import wf.bitcoin.javabitcoindrpcclient.BitcoindRpcClient.MultiSig;
  * 
  * @see <a href="https://bitcoincore.org/en/doc/0.18.0/rpc/">Bitcoin Core RPC documentation</a>
  */
-public class WalletTests extends IntegrationTestBase
+public class WalletTest extends IntegrationTestBase
 {
 	@Test(expected = Test.None.class) // no exception expected
     public void addMultiSigAddressTest()


### PR DESCRIPTION
In order for a test class to be picked up by maven, it must have a name
like Test* / *Test / *TestCase

Therefore, renamed integration test classes ending in *Tests to *Test.