### PR TITLE
Update README with info on how to setup the API endpoint 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,34 @@ The package is published in the wf.bitcoin group and you can add it to you pom.x
     <version>1.1.0</version>
 </dependency>
 ```
+
+
+Configuration
+=====
+In order to know what RPC API to use, the library will look in the bitcoind configuration file (`<user home>/.bitcoin/bitcoin.conf`) and read the relevant configs:
+- rpcuser
+- rpcpassword
+- rpcconnect
+- rpcport
+
+Here is a sample bitcoin.conf that will setup bitcoind to run in regtest mode and in a way compatible with this library:
+
+```
+# Maintain full transaction index, used in lookups by the getrawtransaction call
+txindex=1
+
+# Run bitcoind in regtest mode
+regtest=1
+
+# Accept command line and JSON-RPC commands
+server=1
+
+# Tells bitcoind that the RPC API settings on the following lines apply to the regtest RPC API
+[regtest]
+
+# RPC API settings
+rpcuser=myUsername
+rpcpassword=myPassword
+rpcconnect=localhost
+rpcport=9997
+```

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -726,12 +726,14 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
     return new AddressValidationResultWrapper(m);
   }
 
+  @Deprecated
   @Override
   @SuppressWarnings("unchecked")
   public List<String> generate(int numBlocks) throws BitcoinRPCException {
     return (List<String>) query("generate", numBlocks);
   }
 
+  @Deprecated
   @Override
   @SuppressWarnings("unchecked")
   public List<String> generate(int numBlocks, long maxTries) throws BitcoinRPCException {

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
@@ -189,14 +189,20 @@ public interface BitcoindRpcClient {
    * 
    */
   
-  /**
-   * The generate RPC nearly instantly generates blocks.
-   *
-   * @param numBlocks The number of blocks to generate.
-   * @return An array containing the block header hashes of the generated blocks
-   * 
-   * @see <a href="https://bitcoin.org/en/developer-reference#generate">generate</a>
-   */
+  	/**
+	 * The generate RPC nearly instantly generates blocks.
+	 *
+	 * @param numBlocks The number of blocks to generate.
+	 * @return An array containing the block header hashes of the generated blocks
+	 * 
+	 * @see <a href="https://bitcoin.org/en/developer-reference#generate">generate</a>
+	 * 
+	 * @deprecated The wallet generate rpc method is deprecated and will be fully
+	 *             removed in v0.19. To use generate in v0.18, restart bitcoind with
+	 *             -deprecatedrpc=generate. Clients should transition to using the
+	 *             node rpc method generatetoaddress
+	 */
+  @Deprecated
   List<String> generate(int numBlocks) throws BitcoinRPCException;
 
   /**
@@ -207,7 +213,13 @@ public interface BitcoindRpcClient {
    * @return An array containing the block header hashes of the generated blocks
    * 
    * @see <a href="https://bitcoin.org/en/developer-reference#generate">generate</a>
+   * 
+   * @deprecated The wallet generate rpc method is deprecated and will be fully
+   * 			removed in v0.19. To use generate in v0.18, restart bitcoind with
+   * 			-deprecatedrpc=generate. Clients should transition to using the
+   * 			node rpc method generatetoaddress
    */
+  @Deprecated
   List<String> generate(int numBlocks, long maxTries) throws BitcoinRPCException;
 
   /**


### PR DESCRIPTION
Info includes a sample bitcoin.conf to be used in regtest mode, especially useful when testing the API library.