### PR TITLE
Added support for token-based API authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ The package is published in the wf.bitcoin group and you can add it to you pom.x
 Configuration
 =====
 In order to know what RPC API to use, the library will look in the bitcoind configuration file (`<user home>/.bitcoin/bitcoin.conf`) and read the relevant configs:
-- rpcuser
-- rpcpassword
 - rpcconnect
 - rpcport
 
@@ -40,8 +38,8 @@ server=1
 [regtest]
 
 # RPC API settings
-rpcuser=myUsername
-rpcpassword=myPassword
 rpcconnect=localhost
 rpcport=9997
 ```
+
+Note that the configuration does not contain any API credentials. The authentication is done via a temporary token stored in a cookie file by bitcoind (see [details](https://bitcoin.org/en/release/v0.12.0#rpc-random-cookie-rpc-authentication)). The approach of using rpcuser and rpcpassword is still supported, even though bitcoind considers it legacy.

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
             </goals>
             <configuration>
               <additionalOptions>-Xdoclint:none</additionalOptions>
+              <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
+		<configuration>
+			<!-- Set skip to true, if running "mvn build" in an environment where gpg keys are not available -->
+			<skip>false</skip>
+		</configuration>
         <version>1.6</version>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
 		<configuration>
-			<!-- Set skip to true, if running "mvn build" in an environment where gpg keys are not available -->
+			<!-- Set skip to true, if running "mvn install" in an environment where gpg keys are not available -->
 			<skip>false</skip>
 		</configuration>
         <version>1.6</version>

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -134,9 +134,9 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
         			+ "To use newer auth mechanism based on a temporary password, remove the property rpcauth from bitcoin.conf");
         }
         
-        // Look for .cookie file, which is in a subfolder of the home folder
+        // Look for .cookie file, which is in a subfolder of the .bitcoin folder
         // Subfolder is one of regtest, testnet3, or mainnet - depending on which mode bitcoind is currently using
-        Optional<Path> cookieFile = Files.walk(home.toPath())
+        Optional<Path> cookieFile = Files.walk(configFile.getParentFile().toPath())
         		.filter(f -> f.toFile().getName().equals(".cookie"))
         		.findFirst();
         

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -33,6 +33,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -41,6 +43,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -75,28 +78,81 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
     String port = null;
 
     try {
-      File f;
+      File configFile = null;
       File home = new File(System.getProperty("user.home"));
-
-      if ((f = new File(home, ".bitcoin" + File.separatorChar + "bitcoin.conf")).exists()) {
-      } else if ((f = new File(home, "AppData" + File.separatorChar + "Roaming" + File.separatorChar + "Bitcoin" + File.separatorChar + "bitcoin.conf")).exists()) {
-      } else {
-        f = null;
+      
+      if ((configFile = new File(home, ".bitcoin" + File.separatorChar + "bitcoin.conf")).exists())
+      {
+    	  // Look for the config file on the Linux path
+      }
+      else if ((configFile = new File(home, "AppData" + File.separatorChar + "Roaming" + File.separatorChar + "Bitcoin" + File.separatorChar + "bitcoin.conf")).exists())
+      {
+    	  // Look for the cofig file on the Windows path
       }
 
-      if (f != null) {
+      // If config file is found, attempt to parse its contents
+      if (configFile != null) {
         logger.fine("Bitcoin configuration file found");
 
-        Properties p = new Properties();
-        try (FileInputStream i = new FileInputStream(f)) {
-          p.load(i);
+        Properties configProps = new Properties();
+        try (FileInputStream i = new FileInputStream(configFile)) {
+          configProps.load(i);
         }
 
-        user = p.getProperty("rpcuser", user);
-        password = p.getProperty("rpcpassword", password);
-        host = p.getProperty("rpcconnect", host);
-        port = p.getProperty("rpcport", port);
+        user = configProps.getProperty("rpcuser", user);
+        password = configProps.getProperty("rpcpassword", password);
+        host = configProps.getProperty("rpcconnect", host);
+        port = configProps.getProperty("rpcport", port);
+        
+        // rpcuser and rpcpassword are being phased out of bitcoind
+        // bitcoind shows this warning when these configs are used:
+        // "Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth"
+        // Two alternatives for authentication are offered:
+        // 1) the config rpcauth, which has the format {0}:{1}${2} containing username, salt, password_hmac
+        // See https://github.com/bitcoin/bitcoin/tree/master/share/rpcauth
+        // However, this only contains a hash of the password
+        // This means the password (which is needed in cleartext for authenticaton) cannot be retrieved anymore from bitcoin.conf
+        // 2) the .cookie temporary file
+        // When bitcoind starts (and rpcuser / rpcauth are not used), it creates a temporary .cookie file
+        // This contains a temporary password for the RPC API
+        // The .cookie file is automatically deleted when bitcoind is stopped
+        // Option 2) seems like the best one to use for this client, so warn user if rpcuser / rpcpassword are still used
+        
+        // Show warning if legacy auth mechanism (using rpcuser / rpcpassword) detected
+        if (configProps.getProperty("rpcuser") != null || configProps.getProperty("rpcpassword") != null)
+        {
+        	logger.warning("Currently relying on rpcuser / rpcpassword for authentication. "
+        			+ "This will soon be deprecated in bitcoind. "
+        			+ "To use newer auth mechanism based on a temporary password, remove properties rpcuser / rpcpassword from bitcoin.conf");
+        }
+        
+        // Also show warning if rpcauth mechanism is detected
+        if (configProps.getProperty("rpcauth") != null)
+        {
+        	logger.severe("Currently relying on rpcauth mechanism for authentication. "
+        			+ "This cannot be used by this library, because the password needed for API authentication cannot be retrieved from bitcoin.conf. "
+        			+ "To use newer auth mechanism based on a temporary password, remove the property rpcauth from bitcoin.conf");
+        }
+        
+        // Look for .cookie file, which is in a subfolder of the home folder
+        // Subfolder is one of regtest, testnet3, or mainnet - depending on which mode bitcoind is currently using
+        Optional<Path> cookieFile = Files.walk(home.toPath())
+        		.filter(f -> f.toFile().getName().equals(".cookie"))
+        		.findFirst();
+        
+        if (cookieFile.isPresent())
+        {
+        	Path cookieFilePath = cookieFile.get();
+        	
+            // Format is __cookie__:tempPassword
+            String cookieFileContents = new String(Files.readAllBytes(cookieFilePath));
+            
+            String[] temp = cookieFileContents.split(":");
+            user = temp[0];
+            password = temp[1];
+        }
       }
+      
     } catch (Exception ex) {
       logger.log(Level.SEVERE, null, ex);
     }


### PR DESCRIPTION
Since rpcuser and rpcpassword are considered legacy by bitcoind, the
library now also supports the more future-proof approach of using an
authentication token.

For backward compatibility, rpcuser and rpcpassword are still supported. However, when using them, bitcoind already shows the following warning:

"Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcauth for rpcauth auth generation."