### PR TITLE
Moved sometimes-failing RawTransactionTests to examples package

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -2533,10 +2533,9 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
     }
   }
 
+  @SuppressWarnings("serial")
   private class UnspentWrapper extends MapWrapper implements Unspent {
     
-	private static final long serialVersionUID = -1879303578294482585L;
-
 	private UnspentWrapper(Map<String, ?> m) {
       super(m);
     }

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/util/Chain.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/util/Chain.java
@@ -1,0 +1,13 @@
+package wf.bitcoin.javabitcoindrpcclient.util;
+
+/**
+ * Represents the possible values of the chain we're running on.
+ * <br><br>
+ * Defined by the property "chain" of https://bitcoin.org/en/developer-reference#getblockchaininfo
+ */
+public enum Chain
+{
+	MAIN,
+	TEST,
+	REGTEST;
+}

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/util/Util.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/util/Util.java
@@ -1,0 +1,19 @@
+package wf.bitcoin.javabitcoindrpcclient.util;
+
+import wf.bitcoin.javabitcoindrpcclient.BitcoindRpcClient;
+import wf.bitcoin.javabitcoindrpcclient.BitcoindRpcClient.BlockChainInfo;
+
+public class Util
+{
+	public static void ensureRunningOnChain(Chain chain, BitcoindRpcClient client) throws Exception
+	{
+		BlockChainInfo blockChainInfo = client.getBlockChainInfo();
+		
+		String expectedChain = chain.toString().toLowerCase();
+		String actualChain = blockChainInfo.chain();
+		
+    	if (!actualChain.equals(expectedChain))
+    		throw new Exception("Expected to run on the " + expectedChain + " blockchain, "
+    				+ "but client is configured to use: " + actualChain);
+	}
+}

--- a/src/test/java/wf/bitcoin/javabitcoindrpcclient/integration/IntegrationTestBase.java
+++ b/src/test/java/wf/bitcoin/javabitcoindrpcclient/integration/IntegrationTestBase.java
@@ -10,7 +10,8 @@ import org.junit.BeforeClass;
 
 import wf.bitcoin.javabitcoindrpcclient.BitcoinJSONRPCClient;
 import wf.bitcoin.javabitcoindrpcclient.BitcoindRpcClient;
-import wf.bitcoin.javabitcoindrpcclient.BitcoindRpcClient.BlockChainInfo;
+import wf.bitcoin.javabitcoindrpcclient.util.Chain;
+import wf.bitcoin.javabitcoindrpcclient.util.Util;
 
 /**
  * Common framework for integration tests
@@ -33,12 +34,7 @@ public class IntegrationTestBase
     	
     	client = new BitcoinJSONRPCClient();
     	
-    	BlockChainInfo blockChainInfo = client.getBlockChainInfo();
-    	
-    	String expectedBlockChain = "regtest";
-    	if (!blockChainInfo.chain().equals(expectedBlockChain))
-    		throw new Exception("Integration tests expected to run on the " + expectedBlockChain + " blockchain, "
-    				+ "but client is configured to use: " + blockChainInfo.chain());
+    	Util.ensureRunningOnChain(Chain.REGTEST, client);
     }
     
     protected void assertStringNotNullNorEmpty(String s)


### PR DESCRIPTION
The unstable tests have been converted to examples of how to use the client, with instructions on how to setup the environment for running the examples.

The manual setup steps would have been necessary before each test run, to guarantee a successful test run, which was impractical.