### PR TITLE
Introduced config framework + made bitcoin.conf location configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,18 @@
       <scope>test</scope>
     </dependency>
     
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.9</version>
-		</dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.9</version>
+    </dependency>
+		
+    <!-- https://github.com/lviggiano/owner -->
+    <dependency>
+      <groupId>org.aeonbits.owner</groupId>
+      <artifactId>owner-java8</artifactId>
+      <version>1.0.10</version>
+    </dependency>
 		
   </dependencies>
 

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -52,6 +52,9 @@ import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 
+import org.apache.commons.lang3.StringUtils;
+
+import wf.bitcoin.javabitcoindrpcclient.config.RpcClientConfig;
 import wf.bitcoin.krotjson.Base64Coder;
 import wf.bitcoin.krotjson.HexCoder;
 import wf.bitcoin.krotjson.JSON;
@@ -80,8 +83,16 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
     try {
       File configFile = null;
       File home = new File(System.getProperty("user.home"));
+      String manuallyConfiguredDataFolderPath = RpcClientConfig.get().bitcoinCoreDataFolder();
       
-      if ((configFile = new File(home, ".bitcoin" + File.separatorChar +
+      if (!StringUtils.isEmpty(manuallyConfiguredDataFolderPath) &&
+    		  (configFile = new File(manuallyConfiguredDataFolderPath, "bitcoin.conf")
+    		  ).exists())
+      {
+    	  // Look for the config file in the configured bitcoin core data folder
+    	  logger.fine("Using configured data dir: " + manuallyConfiguredDataFolderPath);
+      }
+      else if ((configFile = new File(home, ".bitcoin" + File.separatorChar +
     		  							"bitcoin.conf")
     		  ).exists())
       {

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/config/RpcClientConfig.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/config/RpcClientConfig.java
@@ -1,0 +1,11 @@
+package wf.bitcoin.javabitcoindrpcclient.config;
+
+import org.aeonbits.owner.ConfigCache;
+
+public class RpcClientConfig
+{
+	public static RpcClientConfigI get()
+	{
+		return ConfigCache.getOrCreate(RpcClientConfigI.class);
+	}
+}

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/config/RpcClientConfigI.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/config/RpcClientConfigI.java
@@ -1,0 +1,19 @@
+package wf.bitcoin.javabitcoindrpcclient.config;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.Config.Sources;
+
+//See https://github.com/lviggiano/owner
+@Sources({ "classpath:config.properties" })
+public interface RpcClientConfigI extends Config
+{
+	/**
+	 * Similar to the -datadir argument given to the bitcoin core binary
+	 * <br><br>
+	 * Using this will cause the RPC Client to look for bitcoin.conf in this path
+	 * 
+	 * @return Manually specified bitcoin-core data folder path
+	 */
+	@Key("core.dataFolder.path")
+	String bitcoinCoreDataFolder();
+}

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -1,0 +1,5 @@
+# Comment out the lines below to specify config options
+# The values are programatically read via wf.bitcoin.javabitcoindrpcclient.config.RpcClientConfig.get()...
+
+# Specifies the bitcoin core data folder
+# core.dataFolder.path=/home/user/new-bitcoin-data-folder


### PR DESCRIPTION
The config framework allows the RPC client to be configured via a
config.properties file. The config values are read programatically and
can have any data type (the framework converts and casts automatically
to the right type).

As an example, introduced a config paramter for the location of the
bitcoin core data folder. This allows the caller to specify a custom
location for this folder, where the RPC client will look for the
bitcoin.conf file.