### PR TITLE
[resolves Polve#108] getTxOut() should fail on invalid/spent TxOut #108

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -1044,7 +1044,7 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
   public TxOut getTxOut(String txId, long vout) throws GenericRpcException {
     TxOutWrapper txOut = new TxOutWrapper((Map<String, ?>) query("gettxout", txId, vout, true));
     if (txOut.m == null) {
-      throw new BitcoinRPCException("Invalid TxOut: " + txId+":"+vout);
+      return null;
     }
     return txOut;
   }
@@ -1053,7 +1053,7 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
   public TxOut getTxOut(String txId, long vout, boolean includemempool) throws GenericRpcException {
     TxOutWrapper txOut = new TxOutWrapper((Map<String, ?>) query("gettxout", txId, vout, includemempool));
     if (txOut.m == null) {
-      throw new BitcoinRPCException("Invalid TxOut: " + txId+":"+vout);
+      return null;
     }
     return txOut;
   }

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -1042,12 +1042,20 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
   @Override
   @SuppressWarnings("unchecked")
   public TxOut getTxOut(String txId, long vout) throws GenericRpcException {
-    return new TxOutWrapper((Map<String, ?>) query("gettxout", txId, vout, true));
+    TxOutWrapper txOut = new TxOutWrapper((Map<String, ?>) query("gettxout", txId, vout, true));
+    if (txOut.m == null) {
+      throw new BitcoinRPCException("Invalid TxOut: " + txId+":"+vout);
+    }
+    return txOut;
   }
 
   @SuppressWarnings("unchecked")
   public TxOut getTxOut(String txId, long vout, boolean includemempool) throws GenericRpcException {
-    return new TxOutWrapper((Map<String, ?>) query("gettxout", txId, vout, includemempool));
+    TxOutWrapper txOut = new TxOutWrapper((Map<String, ?>) query("gettxout", txId, vout, includemempool));
+    if (txOut.m == null) {
+      throw new BitcoinRPCException("Invalid TxOut: " + txId+":"+vout);
+    }
+    return txOut;
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
Raise an exception when BitcoinJSONRPCClient.getTxOut() is called for an invalid or spent TxOut, instead of returning unusable empty object.

(thx for your lib!)