### PR TITLE
Add support for batch requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .project
 .settings
 target
+*.iml
+.idea

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCError.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCError.java
@@ -28,12 +28,15 @@ import java.util.Map;
 public class BitcoinRPCError {
     private int code;
     private String message;
+    private Object id;
 
     @SuppressWarnings({ "rawtypes" })
-    public BitcoinRPCError(Map errorMap) {
-        Number n = (Number) errorMap.get("code");
+    public BitcoinRPCError(Map errorResponse) {
+        Map error = (Map)errorResponse.get("error");
+        Number n = (Number) error.get("code");
         this.code    = n != null ? n.intValue() : 0;
-        this.message = (String) errorMap.get("message");
+        this.message = (String) error.get("message");
+        this.id = errorResponse.get("id");
     }
 
     /**
@@ -46,5 +49,9 @@ public class BitcoinRPCError {
 
     public String getMessage() {
         return message;
+    }
+
+    public Object getId(){
+        return id;
     }
 }

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCException.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinRPCException.java
@@ -48,8 +48,8 @@ public class BitcoinRPCException extends GenericRpcException {
    */
   @SuppressWarnings("rawtypes")
   public BitcoinRPCException(String method, 
-                             String params, 
-                             int    responseCode, 
+                             String params,
+                             int    responseCode,
                              String responseMessage, 
                              String response) {
     super("RPC Query Failed (method: " + method + ", params: " + params + ", response code: " + responseCode + " responseMessage " + responseMessage + ", response: " + response);
@@ -86,7 +86,7 @@ public class BitcoinRPCException extends GenericRpcException {
 
   public BitcoinRPCException(BitcoinRPCError error) {
       super(error.getMessage());
-      this.rpcError  = error;
+      this.rpcError = error;
   }
   
   public BitcoinRPCException(String message, Throwable cause) {

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
@@ -1775,6 +1775,8 @@ public interface BitcoindRpcClient {
 
   interface RawTransaction extends MapWrapperType, Serializable {
 
+   String error();
+
     String hex();
 
     String txId();

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
@@ -427,6 +427,15 @@ public interface BitcoindRpcClient {
   RawTransaction getRawTransaction(String txId) throws GenericRpcException;
 
   /**
+   * Get list of raw transactions
+   *
+   * @param txIds The TXIDs of the transactions to get, encoded as hex in RPC byte order
+   *
+   * @see #getRawTransaction(String) for details
+   */
+  List<RawTransaction> getRawTransactions(List<String> txIds) throws GenericRpcException;
+
+  /**
    * The getrawtransaction RPC gets a hex-encoded serialized transaction.
    * 
    * @param txId The TXID of the transaction to get, encoded as hex in RPC byte order


### PR DESCRIPTION
Add getRawTransactions API method

Now it able to perform batch requests to RPC. 
Added `getRawTransaction(List<String> txIds)` method using this feature. Usage example:

```
	List<String> txIds = new ArrayList<>();
	txIds.add("a6ba14dd74c4e8cd9f3562c233c636900a0c6ceff6f36bb514edd099083b41fa");
	txIds.add("35108b01a35d35fbae298b3eb4ac40a6bdf1b08893e5a075dc19989516933659");
	List<BitcoindRpcClient.RawTransaction> rawTransactions = client.getRawTransactions(txIds);
```