### PR TITLE
Add rescanblockchain method

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -77,7 +77,6 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
 
   public static final Charset QUERY_CHARSET = Charset.forName("ISO8859-1");
   public static final int CONNECT_TIMEOUT = (int) TimeUnit.MINUTES.toMillis(1);
-  public static final int READ_TIMEOUT = (int) TimeUnit.MINUTES.toMillis(5);
 
   static {
     String user = "user";
@@ -205,6 +204,8 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
   private SSLSocketFactory sslSocketFactory;
   private URL noAuthURL;
   private String authStr;
+
+  public int readTimeout = (int) TimeUnit.MINUTES.toMillis(5);
 
   public BitcoinJSONRPCClient(String rpcUrl) throws MalformedURLException {
     this(new URL(rpcUrl));
@@ -349,7 +350,7 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
       conn.setDoInput(true);
 
       conn.setConnectTimeout(CONNECT_TIMEOUT);
-      conn.setReadTimeout(READ_TIMEOUT);
+      conn.setReadTimeout(readTimeout);
 
       if (conn instanceof HttpsURLConnection) {
         if (hostnameVerifier != null)
@@ -644,6 +645,25 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
   @Override
   public void importPrivKey(String bitcoinPrivKey, String label, boolean rescan) throws GenericRpcException {
     query("importprivkey", bitcoinPrivKey, label, rescan);
+  }
+
+  /**
+   * Rescan the local blockchain for wallet related transactions. This method
+   * without argument rescan all the blocks.
+   * The read timeout is set to half a day. because this method take a while. It
+   * depends on hardware and blockchain size. Original timeout is restore after
+   * the query.
+   *
+   * @see <a href="https://bitcoincore.org/en/doc/0.20.0/rpc/wallet/rescanblockchain/">rescanblockchain</a>
+   * */
+  @Override
+  public void rescanBlockchain() throws GenericRpcException {
+    int savedReadTimeout = this.readTimeout;
+    // Change the read timeout to restore it after
+    this.readTimeout = (int) TimeUnit.MINUTES.toMillis(720);
+    query("rescanblockchain");
+    // Restore the previous timeout
+    this.readTimeout = savedReadTimeout;
   }
 
   @Override

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoindRpcClient.java
@@ -854,6 +854,14 @@ public interface BitcoindRpcClient {
   void importPrivKey(String bitcoinPrivKey, String account, boolean rescan) throws GenericRpcException;
 
   /**
+   * Rescan the local blockchain for wallet related transactions. This method
+   * without argument rescan all the blocks.
+   *
+   * @see <a href="https://bitcoincore.org/en/doc/0.20.0/rpc/wallet/rescanblockchain/">rescanblockchain</a>
+   */
+  void rescanBlockchain() throws GenericRpcException;
+
+  /**
    * The importwallet RPC imports private keys from a file in wallet dump file format (see the dumpwallet RPC). 
    * These keys will be added to the keys currently in the wallet.
    *  


### PR DESCRIPTION
The rescanblockchain method is absent. It is a really useful command to insert several private keys without rescanning and only rescan once they are all inserted.
The BitcoinRPCClient as a READ_TIMEOUT private static final of 1 minute. It is too short for rescanning after a single import passing the option to importprivatekey or rescanning with rescanblockchain.