### PR TITLE
Fix address mapping for vouts

### DIFF
--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -35,11 +35,22 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.Collections;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
@@ -2384,7 +2395,11 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
         @SuppressWarnings("unchecked")
         public List<String> addresses() {
           List<String> addresses = ((List<String>) m.get("addresses"));
-          return addresses == null? Collections.singletonList(mapStr("address")): addresses;
+          if (addresses == null) {
+            final String address = mapStr("address");
+            return address == null? Collections.emptyList() : Collections.singletonList(address);
+          }
+          return addresses;
         }
 
       }

--- a/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
+++ b/src/main/java/wf/bitcoin/javabitcoindrpcclient/BitcoinJSONRPCClient.java
@@ -35,17 +35,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.AbstractList;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -2393,7 +2383,8 @@ public class BitcoinJSONRPCClient implements BitcoindRpcClient {
         @Override
         @SuppressWarnings("unchecked")
         public List<String> addresses() {
-          return (List<String>) m.get("addresses");
+          List<String> addresses = ((List<String>) m.get("addresses"));
+          return addresses == null? Collections.singletonList(mapStr("address")): addresses;
         }
 
       }


### PR DESCRIPTION
bitcoin documentation seems to be invalid https://developer.bitcoin.org/reference/rpc/decoderawtransaction.html 
actual tx document contains single address instead of list please look at source code  https://github.com/bitcoin/bitcoin/blob/master/src/rpc/rawtransaction.cpp#L185 on the other hand there are places where multiple addresses gets returned https://github.com/bitcoin/bitcoin/blob/master/src/rpc/rawtransaction.cpp#L104